### PR TITLE
Lazy-load ActionView::Base to defer :action_view on_load hook

### DIFF
--- a/lib/buoys.rb
+++ b/lib/buoys.rb
@@ -19,4 +19,5 @@ module Buoys
     end
   end
 end
-ActionView::Base.send :include, Buoys::Helper
+
+require 'buoys/railtie'

--- a/lib/buoys/railtie.rb
+++ b/lib/buoys/railtie.rb
@@ -1,0 +1,9 @@
+module Buoys
+  class Railtie < ::Rails::Railtie
+    initializer 'buoys' do |_app|
+      ActiveSupport.on_load(:action_view) do
+        ActionView::Base.send :include, Buoys::Helper
+      end
+    end
+  end
+end


### PR DESCRIPTION
Bundling current version of buoys immediately loads ActionView::Base when the gem is required, and thus triggers its whole initialization scripts even in situations that ActionView is not actually needed.

Here's a fix to lazy-load AV::Base via ActiveSupport.on_load hook so that AV::Base is loaded when actually referenced from the application.