### PR TITLE
Do not drop second args

### DIFF
--- a/lib/buoys/renderer.rb
+++ b/lib/buoys/renderer.rb
@@ -1,14 +1,14 @@
 module Buoys
   class Renderer
     def initialize(context, key, *args)
-      @context, @key, @args = context, key, *args
+      @context, @key, @args = context, key, args
       Buoys::Loader.load_buoys_files if Buoys::Loader.buoys.keys.empty?
     end
 
     def render
       return [] unless @key
 
-      buoy = Buoys::Buoy.new(@context, @key, @args)
+      buoy = Buoys::Buoy.new(@context, @key, *@args)
       build_links(buoy)
     end
 

--- a/test/buoys_helper_test.rb
+++ b/test/buoys_helper_test.rb
@@ -26,6 +26,13 @@ class BuoysHelerTest < ActionView::TestCase
     assert_dom_equal %{<ul><li><a class="hover" href="https://example.com/help"><span>help</span></a><span>&gt;</span></li><li><a class="active" href=""><span>usage</span></a></li></ul>}, html
   end
 
+  test '.buoy (receive multiple arguments)' do
+    breadcrumb :edit_book_author, 1, 2
+    html = render('breadcrumbs/buoys').gsub(/[[:space:]]{2,}|\n/, '')
+
+    assert_dom_equal %{<ul><li><a class="hover" href="http://example.com/books"><span>Books</span></a><span>&gt;</span></li><li><a class="active" href="http://example.com/books/1/authors/2"><span>edit-1-2</span></a></li></ul>}, html
+  end
+
   test ".buoy (has configuration options in link's arguments)" do
     breadcrumb :show_books, 1
     html = render('breadcrumbs/buoys').gsub(/[[:space:]]{2,}|\n/, '')

--- a/test/dummy/config/buoys/buoys.rb
+++ b/test/dummy/config/buoys/buoys.rb
@@ -10,3 +10,8 @@ buoy :show_books do |number|
   parent :books
   link "show-#{number}", "http://example.com/books/#{number}", link_current: true
 end
+
+buoy :edit_book_author do |book_id, author_id|
+  parent :books
+  link "edit-#{book_id}-#{author_id}", "http://example.com/books/#{book_id}/authors/#{author_id}", link_current: true
+end


### PR DESCRIPTION
Second args has dropped when definition is like following

```haml
- buoy :index, @a, @b