### PR TITLE
Add options to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,16 @@ Start by generating configuration and example files.
 ```ruby
 $ bin/rails g buoys:install
   create  config/locale/buoys.en.yml
-  create  app/views/breadcrumbs/_buoys.html.erb
   create  config/buoys/breadcrumbs.rb
+  create  app/views/breadcrumbs/_buoys.html.erb
+```
+
+You can use `--template haml` and `--template slim` options.
+```ruby
+$ bin/rails g buoys:install --template haml
+  create  config/locale/buoys.en.yml
+  create  config/buoys/breadcrumbs.rb
+  create  app/views/breadcrumbs/_buoys.html.haml
 ```
 
 Then, in `config/buoys/breadcrumbs.rb`

--- a/lib/generators/buoys/install_generator.rb
+++ b/lib/generators/buoys/install_generator.rb
@@ -4,10 +4,17 @@ module Buoys
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
 
+    class_option :template
+
     def create_files
       copy_file 'buoys.en.yml', 'config/locales/buoys.en.yml'
-      copy_file '_buoys.html.erb', 'app/views/breadcrumbs/_buoys.html.erb'
       copy_file 'breadcrumbs.rb', 'config/buoys/breadcrumbs.rb'
+
+      if %(haml slim).include?(template_type = options[:template])
+        copy_file "_buoys.html.#{template_type}", "app/views/breadcrumbs/_buoys.html.#{template_type}"
+      else
+        copy_file '_buoys.html.erb', 'app/views/breadcrumbs/_buoys.html.erb'
+      end
     end
   end
 end

--- a/lib/generators/buoys/templates/_buoys.html.haml
+++ b/lib/generators/buoys/templates/_buoys.html.haml
@@ -1,0 +1,9 @@
+- if buoys.any?
+  %ol.breadcrumb
+    - buoys.each do |link|
+      %li
+        - # if `link.current?` is true, link.options includes {class: 'current'}.
+        - if link.current?
+          %span= link.text
+        - else
+          = link_to link.text, link.url, link.options

--- a/lib/generators/buoys/templates/_buoys.html.slim
+++ b/lib/generators/buoys/templates/_buoys.html.slim
@@ -1,0 +1,10 @@
+- if buoys.any?
+  ol.breadcrumb
+    - buoys.each do |link|
+      li
+        - # if `link.current?` is true, link.options includes {class: 'current'}.
+        - if link.current?
+          span
+            = link.text
+        - else
+          = link_to link.text, link.url, link.options

--- a/lib/tasks/buoy_tasks.rake
+++ b/lib/tasks/buoy_tasks.rake
@@ -1,4 +1,0 @@
-# desc "Explaining what the task does"
-# task :buoy do
-#   # Task goes here
-# end


### PR DESCRIPTION
I add option `template` so you can generate _buoys.html.haml or _buoys.html.slim.

```ruby
$ bin/rails g buoys:install --template haml
```
```ruby
$ bin/rails g buoys:install --template slim
```