### PR TITLE
Use more efficient reloading condition

### DIFF
--- a/lib/buoys/loader.rb
+++ b/lib/buoys/loader.rb
@@ -19,16 +19,30 @@ module Buoys
         @buoys ||= {}
       end
 
+      def loaded_times
+        @loaded_times ||= []
+      end
+
       def load_buoys_files
+        return unless need_reload?
+
         buoys.clear
+        loaded_times.clear
 
         buoy_files.each do |file|
           instance_eval open(file).read, file
+          loaded_times << File.mtime(file)
         end
       end
 
       def buoy_files
         Dir[*Buoys.buoy_file_paths]
+      end
+
+      def need_reload?
+        return true if buoys.empty?
+
+        Rails.env.development? && loaded_times != buoy_files.map {|f| File.mtime(f) }
       end
     end
   end

--- a/lib/buoys/renderer.rb
+++ b/lib/buoys/renderer.rb
@@ -3,9 +3,7 @@ module Buoys
     def initialize(context, key, *args)
       @context, @key, @args = context, key, args
 
-      if Rails.env.development? || Buoys::Loader.buoys.keys.empty?
-        Buoys::Loader.load_buoys_files
-      end
+      Buoys::Loader.load_buoys_files
     end
 
     def render


### PR DESCRIPTION
reload if buoy files' mtime are different before.

First, I'm going to create reloading mechanism which reloads only changed files, but it will remain removed buoy's definitions.:cry: So, I decide to choose all-or-none reloading.