### PR TITLE
Use rails5.0.0.rc1 and revise gemfiles' names in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ gemfile:
   - gemfiles/Gemfile-rails4.2.x
   - gemfiles/Gemfile-rails5.0.x
 
+matrix:
+  allow_failures:
+    - rvm: 2.1.10
+      gemfile: gemfiles/Gemfile-rails5.0.x
+
 before_script:
   - 'cd test/dummy; rake db:migrate; rake db:test:prepare; cd ../..'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ rvm:
   - 2.3.1
 
 gemfile:
-  - gemfiles/Gemfile-4.1.x
-  - gemfiles/Gemfile-4.2.x
-  - gemfiles/Gemfile-5.0.x
+  - gemfiles/Gemfile-rails4.1.x
+  - gemfiles/Gemfile-rails4.2.x
+  - gemfiles/Gemfile-rails5.0.x
 
 before_script:
   - 'bundle install'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ gemfile:
   - gemfiles/Gemfile-rails5.0.x
 
 before_script:
-  - 'bundle install'
   - 'cd test/dummy; rake db:migrate; rake db:test:prepare; cd ../..'
 
 notifications:

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -21,6 +21,8 @@ module Dummy
     config.i18n.default_locale = :en
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
+    if Gem::Version.new(Rails.version) >= Gem::Version.new("4.2.0")
+      config.active_record.raise_in_transactional_callbacks = true
+    end
   end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  get 'about'         => 'dummy/dummy', as: :about
-  get 'about/history' => 'dummy/dummy', as: :history
+  get 'about'         => 'dummy#dummy', as: :about
+  get 'about/history' => 'dummy#dummy', as: :history
 end


### PR DESCRIPTION
I update rails version in `gemfiles/Gemfile-rails5.0.x` and revise Gemfiles' names because they have been wrong until now. :cry: