### PR TITLE
Enable to use polymorphic path

### DIFF
--- a/lib/buoys/buoy.rb
+++ b/lib/buoys/buoy.rb
@@ -34,7 +34,7 @@ module Buoys
     end
 
     def pre_buoy(key, *args)
-      @previous = Buoys::Buoy.new(context, key, args)
+      @previous = Buoys::Buoy.new(context, key, *args)
     end
     alias parent pre_buoy
 

--- a/test/buoys_helper_test.rb
+++ b/test/buoys_helper_test.rb
@@ -71,7 +71,7 @@ class BuoysHelerTest < ActionView::TestCase
             <span>&gt;</span>
           </li>
           <li>
-            <a class="active" href="http://example.com/books/1/authors/2">
+            <a class="active" href="http://example.com/books/1/authors/2/edit">
               <span>edit-1-2</span>
             </a>
           </li>

--- a/test/buoys_helper_test.rb
+++ b/test/buoys_helper_test.rb
@@ -81,6 +81,32 @@ class BuoysHelerTest < ActionView::TestCase
     assert_dom_equal expected_html, html
   end
 
+  test '.buoy (use polymorphic routes)' do
+    user = User.create(name: 'test user')
+    item = Item.create(name: 'test item')
+
+    breadcrumb :edit_user_item, [user, item]
+    html = render('breadcrumbs/buoys').gsub(/[[:space:]]{2,}|\n/, '')
+    expected_html =
+      %(
+        <ul>
+          <li>
+            <a class="hover" href="/users/#{user.id}/items/#{item.id}">
+              <span>show user item</span>
+            </a>
+            <span>&gt;</span>
+          </li>
+          <li>
+            <a class="active" href="/users/#{user.id}/items/#{item.id}/edit">
+              <span>edit user item</span>
+            </a>
+          </li>
+        </ul>
+      ).gsub(/[[:space:]]{2,}|\n/, '')
+
+    assert_dom_equal expected_html, html
+  end
+
   test ".buoy (has configuration options in link's arguments)" do
     breadcrumb :show_books, 1
     html = render('breadcrumbs/buoys').gsub(/[[:space:]]{2,}|\n/, '')

--- a/test/dummy/app/controllers/items_controller.rb
+++ b/test/dummy/app/controllers/items_controller.rb
@@ -1,0 +1,6 @@
+class ItemsController < ApplicationController
+  def show
+  end
+  def edit
+  end
+end

--- a/test/dummy/app/models/item.rb
+++ b/test/dummy/app/models/item.rb
@@ -1,0 +1,2 @@
+class Item < ActiveRecord::Base
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ActiveRecord::Base
+end

--- a/test/dummy/config/buoys/buoys.rb
+++ b/test/dummy/config/buoys/buoys.rb
@@ -13,5 +13,5 @@ end
 
 buoy :edit_book_author do |book_id, author_id|
   parent :books
-  link "edit-#{book_id}-#{author_id}", "http://example.com/books/#{book_id}/authors/#{author_id}", link_current: true
+  link "edit-#{book_id}-#{author_id}", "http://example.com/books/#{book_id}/authors/#{author_id}/edit", link_current: true
 end

--- a/test/dummy/config/buoys/buoys.rb
+++ b/test/dummy/config/buoys/buoys.rb
@@ -15,3 +15,12 @@ buoy :edit_book_author do |book_id, author_id|
   parent :books
   link "edit-#{book_id}-#{author_id}", "http://example.com/books/#{book_id}/authors/#{author_id}/edit", link_current: true
 end
+
+buoy :show_user_item do |user, item|
+  link :show_user_item, [user, item]
+end
+
+buoy :edit_user_item do |user, item|
+  pre_buoy :show_user_item, [user, item]
+  link :edit_user_item, [:edit, user, item], link_current: true
+end

--- a/test/dummy/config/locales/en.yml
+++ b/test/dummy/config/locales/en.yml
@@ -25,3 +25,5 @@ en:
   buoys:
     breadcrumbs:
       account: 'Account'
+      show_user_item: 'show user item'
+      edit_user_item: 'edit user item'

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
   get 'about'         => 'dummy#dummy', as: :about
   get 'about/history' => 'dummy#dummy', as: :history
+
+  resources :users, only: [] do
+    resources :items, only: %i(show edit)
+  end
 end

--- a/test/dummy/db/migrate/20160602144150_create_items.rb
+++ b/test/dummy/db/migrate/20160602144150_create_items.rb
@@ -1,0 +1,9 @@
+class CreateItems < ActiveRecord::Migration
+  def change
+    create_table :items do |t|
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/migrate/20160602144324_create_users.rb
+++ b/test/dummy/db/migrate/20160602144324_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration
+  def change
+    create_table :users do |t|
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,6 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20160602144324) do
+
+  create_table "items", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end


### PR DESCRIPTION
I rid bug that `Buoys::Buoy#pre_buoy` cannot take polymorphic path as arguments.

You can write below.

```ruby
buoy :show_user_item do |user, item|
  link :show_user_item, [user, item]
end

buoy :edit_user_item do |user, item|
  pre_buoy :show_user_item, [user, item]
  link :edit_user_item, [:edit, user, item], link_current: true
end
```

Thank you for your report, @takkanm.