### PR TITLE
Add 2.3.2 and 2.2.6 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 sudo: false
 rvm:
   - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.2
   - ruby-head
 
 gemfile:

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -21,7 +21,7 @@ module Dummy
     config.i18n.default_locale = :en
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
-    if Gem::Version.new(Rails.version) >= Gem::Version.new("4.2.0")
+    if Gem::Version.new(Rails.version) >= Gem::Version.new("4.2.0") && Gem::Version.new(Rails.version) <= Gem::Version.new("5.0.0")
       config.active_record.raise_in_transactional_callbacks = true
     end
   end

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -13,8 +13,13 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
-  config.static_cache_control = 'public, max-age=3600'
+  if Gem::Version.new(Rails.version) >= Gem::Version.new('5.0.0')
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  else
+    config.serve_static_files   = true
+    config.static_cache_control = 'public, max-age=3600'
+  end
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
`buoys` supports Ruby 2.3.2 and 2.2.6, in addition, suppress warnings for Rails 5.1 in `test/dummy/config/environments/test.rb`