### PR TITLE
CI against Rails 5.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ gemfile:
   - gemfiles/Gemfile-rails4.1.x
   - gemfiles/Gemfile-rails4.2.x
   - gemfiles/Gemfile-rails5.0.x
+  - gemfiles/Gemfile-rails5.1.x
 
 matrix:
   allow_failures:

--- a/gemfiles/Gemfile-rails5.1.x
+++ b/gemfiles/Gemfile-rails5.1.x
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rails', '>= 5.1.0'
+gem 'sqlite3'
+
+gem 'buoys', path: '../'


### PR DESCRIPTION
Rails 5.1 release has been officially cut.
http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final