### PR TITLE
Add magic comment `frozen_string_literal: true` to *.rb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - ruby-head
 
 gemfile:
-  - gemfiles/Gemfile-rails4.1.x
   - gemfiles/Gemfile-rails4.2.x
   - gemfiles/Gemfile-rails5.0.x
   - gemfiles/Gemfile-rails5.1.x
@@ -15,14 +14,9 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: 2.4.1
-      gemfile: gemfiles/Gemfile-rails4.1.x
-    - rvm: 2.4.1
       gemfile: gemfiles/Gemfile-rails4.2.x
     - rvm: ruby-head
-      gemfile: gemfiles/Gemfile-rails4.1.x
-    - rvm: ruby-head
       gemfile: gemfiles/Gemfile-rails4.2.x
-
 
 before_script:
   - 'cd test/dummy; rake db:migrate; rake db:test:prepare; cd ../..'

--- a/buoys.gemspec
+++ b/buoys.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 4.1.0"
+  s.add_dependency "rails", ">= 4.2.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "pry-rails"

--- a/gemfiles/Gemfile-rails4.1.x
+++ b/gemfiles/Gemfile-rails4.1.x
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.1.0'
-gem 'sqlite3'
-
-gem 'buoys', path: '../'

--- a/lib/buoys.rb
+++ b/lib/buoys.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'buoys/version'
 require 'buoys/config'
 require 'buoys/loader'

--- a/lib/buoys/buoy.rb
+++ b/lib/buoys/buoy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Buoys
   class Buoy
     attr_reader :previous, :context

--- a/lib/buoys/config.rb
+++ b/lib/buoys/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Buoys
   class Config
     class << self

--- a/lib/buoys/helper.rb
+++ b/lib/buoys/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Buoys
   module Helper
     # Declare the breadcrumb which want to render in view.

--- a/lib/buoys/link.rb
+++ b/lib/buoys/link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Buoys
   class Link
     attr_accessor :text, :options, :options_for_config

--- a/lib/buoys/loader.rb
+++ b/lib/buoys/loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Buoys
   class Loader
     class << self

--- a/lib/buoys/railtie.rb
+++ b/lib/buoys/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Buoys
   class Railtie < ::Rails::Railtie
     initializer 'buoys' do

--- a/lib/buoys/renderer.rb
+++ b/lib/buoys/renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Buoys
   class Renderer
     def initialize(context, key, *args)

--- a/lib/buoys/version.rb
+++ b/lib/buoys/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Buoys
   VERSION = '0.6.0'.freeze
 end

--- a/lib/generators/buoys/install_generator.rb
+++ b/lib/generators/buoys/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/generators'
 
 module Buoys

--- a/lib/generators/buoys/templates/breadcrumbs.rb
+++ b/lib/generators/buoys/templates/breadcrumbs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 buoy :example do
   link :example, 'http://localhost:3000'
 end

--- a/test/buoys_buoy_test.rb
+++ b/test/buoys_buoy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class BuoysBuoyTest < ActiveSupport::TestCase

--- a/test/buoys_generator_test.rb
+++ b/test/buoys_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Style/RegexpLiteral,Style/PercentLiteralDelimiters
 require 'test_helper'
 require 'generators/buoys/install_generator'

--- a/test/buoys_helper_test.rb
+++ b/test/buoys_helper_test.rb
@@ -12,7 +12,7 @@ class BuoysHelerTest < ActionView::TestCase
     buoy :account
     html = render('breadcrumbs/buoys').gsub(/[[:space:]]{2,}|\n/, '')
 
-    assert_dom_equal %(<ul><li><a class="active" href=""><span>Account</span></a></li></ul>), html
+    assert_dom_equal %(<ul><li><a class="active" href=""><span>Account</span></a></li></ul>).dup, html
   end
 
   test '.buoy (not only active)' do
@@ -137,6 +137,6 @@ class BuoysHelerTest < ActionView::TestCase
     buoys
     html = render('breadcrumbs/buoys').gsub(/[[:space:]]{2,}|\n/, '')
 
-    assert_dom_equal '', html
+    assert_dom_equal ''.dup, html
   end
 end

--- a/test/buoys_helper_test.rb
+++ b/test/buoys_helper_test.rb
@@ -12,7 +12,7 @@ class BuoysHelerTest < ActionView::TestCase
     buoy :account
     html = render('breadcrumbs/buoys').gsub(/[[:space:]]{2,}|\n/, '')
 
-    assert_dom_equal %(<ul><li><a class="active" href=""><span>Account</span></a></li></ul>).dup, html
+    assert_dom_equal %(<ul><li><a class="active" href=""><span>Account</span></a></li></ul>), html
   end
 
   test '.buoy (not only active)' do
@@ -137,6 +137,6 @@ class BuoysHelerTest < ActionView::TestCase
     buoys
     html = render('breadcrumbs/buoys').gsub(/[[:space:]]{2,}|\n/, '')
 
-    assert_dom_equal ''.dup, html
+    assert_dom_equal '', html
   end
 end

--- a/test/buoys_helper_test.rb
+++ b/test/buoys_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/ClassLength
 require 'test_helper'
 

--- a/test/buoys_loader_test.rb
+++ b/test/buoys_loader_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class BuoysLoaderTest < ActiveSupport::TestCase

--- a/test/buoys_test.rb
+++ b/test/buoys_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class BuoysTest < ActiveSupport::TestCase

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/test/dummy/app/controllers/items_controller.rb
+++ b/test/dummy/app/controllers/items_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ItemsController < ApplicationController
   def show
   end

--- a/test/dummy/app/helpers/application_helper.rb
+++ b/test/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/test/dummy/app/models/item.rb
+++ b/test/dummy/app/models/item.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Item < ActiveRecord::Base
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class User < ActiveRecord::Base
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'

--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/test/dummy/config/buoys/breadcrumb.rb
+++ b/test/dummy/config/buoys/breadcrumb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 buoy :about do
   link 'about', about_path
 end

--- a/test/dummy/config/buoys/buoys.rb
+++ b/test/dummy/config/buoys/buoys.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 buoy :account do
   link :account, 'http://example.com/account'
 end

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy/config/initializers/assets.rb
+++ b/test/dummy/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/test/dummy/config/initializers/backtrace_silencers.rb
+++ b/test/dummy/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/dummy/config/initializers/cookies_serializer.rb
+++ b/test/dummy/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/test/dummy/config/initializers/filter_parameter_logging.rb
+++ b/test/dummy/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/test/dummy/config/initializers/inflections.rb
+++ b/test/dummy/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/test/dummy/config/initializers/mime_types.rb
+++ b/test/dummy/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/dummy/config/initializers/session_store.rb
+++ b/test/dummy/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_dummy_session'

--- a/test/dummy/config/initializers/wrap_parameters.rb
+++ b/test/dummy/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   get 'about'         => 'dummy#dummy', as: :about
   get 'about/history' => 'dummy#dummy', as: :history

--- a/test/dummy/db/migrate/20160602144150_create_items.rb
+++ b/test/dummy/db/migrate/20160602144150_create_items.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateItems < ActiveRecord::Migration
   def change
     create_table :items do |t|

--- a/test/dummy/db/migrate/20160602144324_create_users.rb
+++ b/test/dummy/db/migrate/20160602144324_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUsers < ActiveRecord::Migration
   def change
     create_table :users do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 


### PR DESCRIPTION
I've added  `frozen_string_literal: true` to rb files for Ruby 2.3 above.

I think that I should change configurations of Rubocop, but I' ll change them other PR. (Maybe it will spend time.)