### PR TITLE
Add `bundle exec rubocop` to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,9 @@ matrix:
 before_script:
   - 'cd test/dummy; rake db:migrate; rake db:test:prepare; cd ../..'
 
+script:
+  - bundle exec rake test
+  - bundle exec rubocop
+
 notifications:
   email: false

--- a/gemfiles/Gemfile-rails4.2.x
+++ b/gemfiles/Gemfile-rails4.2.x
@@ -4,3 +4,7 @@ gem 'rails', '~> 4.2.0'
 gem 'sqlite3'
 
 gem 'buoys', path: '../'
+
+group :test do
+  gem 'rubocop', '~> 0.49', '>= 0.49.1'
+end

--- a/gemfiles/Gemfile-rails5.0.x
+++ b/gemfiles/Gemfile-rails5.0.x
@@ -4,3 +4,7 @@ gem 'rails', '~> 5.0.0'
 gem 'sqlite3'
 
 gem 'buoys', path: '../'
+
+group :test do
+  gem 'rubocop', '~> 0.49', '>= 0.49.1'
+end

--- a/gemfiles/Gemfile-rails5.1.x
+++ b/gemfiles/Gemfile-rails5.1.x
@@ -4,3 +4,7 @@ gem 'rails', '~> 5.1.0'
 gem 'sqlite3'
 
 gem 'buoys', path: '../'
+
+group :test do
+  gem 'rubocop', '~> 0.49', '>= 0.49.1'
+end


### PR DESCRIPTION
I added `bundle exec rubocop` to script part in .travis.yml and each gemfiles/Gemfile-rails*.
It'll check offences each `git push` and no need to point them out by human.