### PR TITLE
Update supported Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
 
 gemfile:


### PR DESCRIPTION
www.ruby-lang.org has announced the releases of rubies which are patched security fixes, and buoys should support and use them.

related links:
- https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/
- https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/
- https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/
- https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-4-2-released/