### PR TITLE
Update support Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 
 gemfile:
@@ -14,7 +14,7 @@ gemfile:
 
 matrix:
   allow_failures:
-    - rvm: 2.4.1
+    - rvm: 2.4.4
       gemfile: gemfiles/Gemfile-rails4.2.x
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile-rails4.2.x


### PR DESCRIPTION
Add below Ruby versions to .travis.yml and support them if tests are passed.

- 2.2.10
- 2.3.7
- 2.4.4
- 2.5.1

But released rails gems have a problem about Ruby's version checking about 2.2.10, [rails#32370](https://github.com/rails/rails/pull/32370), so I wait for rails' release. (or have to think about other way?)

**Add on 2018-03-30**
[Rails 5.0.7 and 5.1.6 have been released](http://weblog.rubyonrails.org/2018/3/29/Rails-5-0-7-and-5-1-6-have-been-released/) and 5.0.7 and 5.1.6 include a patch which fixes above problem!