### PR TITLE
Add support for rails 5.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ gemfile:
   - gemfiles/Gemfile-rails4.2.x
   - gemfiles/Gemfile-rails5.0.x
   - gemfiles/Gemfile-rails5.1.x
+  - gemfiles/Gemfile-rails5.2.x
 
 matrix:
   allow_failures:

--- a/gemfiles/Gemfile-rails5.2.x
+++ b/gemfiles/Gemfile-rails5.2.x
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 5.2.0'
+gem 'sqlite3'
+
+gem 'buoys', path: '../'
+
+group :test do
+  gem 'rubocop', '~> 0.49', '>= 0.49.1'
+end


### PR DESCRIPTION
[rails 5.2.0](http://weblog.rubyonrails.org/2018/4/9/Rails-5-2-0-final/) is released on April 9, 2018 and buoys follows it.