### PR TITLE
Fix rubocop version to 0.54.0

### DIFF
--- a/gemfiles/Gemfile-rails4.2.x
+++ b/gemfiles/Gemfile-rails4.2.x
@@ -5,6 +5,4 @@ gem 'sqlite3'
 
 gem 'buoys', path: '../'
 
-group :test do
-  gem 'rubocop', '~> 0.54'
-end
+gem 'rubocop', '0.54.0'

--- a/gemfiles/Gemfile-rails5.0.x
+++ b/gemfiles/Gemfile-rails5.0.x
@@ -5,6 +5,4 @@ gem 'sqlite3'
 
 gem 'buoys', path: '../'
 
-group :test do
-  gem 'rubocop', '~> 0.54'
-end
+gem 'rubocop', '0.54.0'

--- a/gemfiles/Gemfile-rails5.1.x
+++ b/gemfiles/Gemfile-rails5.1.x
@@ -5,6 +5,4 @@ gem 'sqlite3'
 
 gem 'buoys', path: '../'
 
-group :test do
-  gem 'rubocop', '~> 0.54'
-end
+gem 'rubocop', '0.54.0'

--- a/gemfiles/Gemfile-rails5.2.x
+++ b/gemfiles/Gemfile-rails5.2.x
@@ -5,6 +5,4 @@ gem 'sqlite3'
 
 gem 'buoys', path: '../'
 
-group :test do
-  gem 'rubocop', '~> 0.49', '>= 0.49.1'
-end
+gem 'rubocop', '~> 0.54.0'


### PR DESCRIPTION
Prevernt CI from running rubocop with higher version and unexpected cops.