### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ buoy :story do |story|
   # same as `link I18n.t('story', scope: 'buoys.breadcrumbs', default: 'story'), story_path(story)`
 end
 
-# You can alse override Buoys configuration
+# You can also override Buoys configuration
 # ex)
 buoy :story_tasks do |story|
   link :story_tasks, story_tasks_path

--- a/lib/generators/buoys/templates/breadcrumbs.rb
+++ b/lib/generators/buoys/templates/breadcrumbs.rb
@@ -23,7 +23,7 @@ end
 #   # same as `link I18n.t(:story, scope: 'buoys.breadcrumbs', default: story), story_path(story)`
 # end
 
-# You can alse override Buoys configuration
+# You can also override Buoys configuration
 #
 # ex)
 # buoy :story_tasks do |story|


### PR DESCRIPTION
`alse` looks like a typo in `also`.