### PR TITLE
Update CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,11 @@ matrix:
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile-rails4.2.x
 
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
+
 before_script:
-  - 'gem update bundler'
   - 'gem install rake --no-document'
   - 'cd test/dummy; rake db:migrate; rake db:test:prepare; cd ../..'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
   - ruby-head
 
 gemfile:
@@ -15,12 +14,15 @@ gemfile:
 
 matrix:
   allow_failures:
-    - rvm: 2.4.4
+    - rvm: 2.5.5
+      gemfile: gemfiles/Gemfile-rails4.2.x
+    - rvm: 2.6.3
       gemfile: gemfiles/Gemfile-rails4.2.x
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile-rails4.2.x
 
 before_script:
+  - 'gem update bundler'
   - 'gem install rake --no-document'
   - 'cd test/dummy; rake db:migrate; rake db:test:prepare; cd ../..'
 

--- a/gemfiles/Gemfile-rails4.2.x
+++ b/gemfiles/Gemfile-rails4.2.x
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.0'
 
 gem 'buoys', path: '../'
 

--- a/gemfiles/Gemfile-rails5.0.x
+++ b/gemfiles/Gemfile-rails5.0.x
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.0'
 
 gem 'buoys', path: '../'
 


### PR DESCRIPTION
I've dropped eol Ruby versions 2.2 and 2.3 support and downgrade sqlite3 and bundler to pass CI for rails 4.2.x and 5.0.x.

see: https://www.ruby-lang.org/en/downloads/branches/