### PR TITLE
Suppress Rails 6.0's warning

### DIFF
--- a/test/buoys_buoy_test.rb
+++ b/test/buoys_buoy_test.rb
@@ -4,7 +4,11 @@ require 'test_helper'
 
 class BuoysBuoyTest < ActiveSupport::TestCase
   setup do
-    @view_context = ActionView::Base.new
+    @view_context = if ActionView::Base.respond_to?(:empty)
+                      ActionView::Base.empty
+                    else
+                      ActionView::Base.new # Rails 5.2 or lower
+                    end
     Buoys::Loader.load_buoys_files
   end
 


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/35093.

This PR suppresses the following warning when using Rails 6.0.

```console
% path/to/buoys
% bundle exec rake

(snip)

DEPRECATION WARNING: ActionView::Base instances should be constructed
with a lookup context, assignments, and a controller. (called from new
at /Users/koic/src/github.com/muryoimpl/buoys/test/buoys_buoy_test.rb:7)
```