### PR TITLE
Drop supported rails version 4.2.x and 5.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ rvm:
   - ruby-head
 
 gemfile:
-  - gemfiles/Gemfile-rails4.2.x
-  - gemfiles/Gemfile-rails5.0.x
-  - gemfiles/Gemfile-rails5.1.x
   - gemfiles/Gemfile-rails5.2.x
   - gemfiles/Gemfile-rails6.0.x
 
@@ -17,10 +14,6 @@ matrix:
   allow_failures:
     - rvm: 2.4.7
       gemfile: gemfiles/Gemfile-rails6.0.x
-    - rvm: 2.5.6
-      gemfile: gemfiles/Gemfile-rails4.2.x
-    - rvm: 2.6.4
-      gemfile: gemfiles/Gemfile-rails4.2.x
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile-rails4.2.x
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ matrix:
     - rvm: 2.4.7
       gemfile: gemfiles/Gemfile-rails6.0.x
     - rvm: ruby-head
-      gemfile: gemfiles/Gemfile-rails4.2.x
+      gemfile: gemfiles/Gemfile-rails5.2.x
+    - rvm: ruby-head
+      gemfile: gemfiles/Gemfile-rails6.0.x
 
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true


### PR DESCRIPTION
Ruby on Rails now only supports 6.0.x and 5.2.x and buoys follows it.

https://rubyonrails.org/maintenance/
https://rubyonrails.org/security/